### PR TITLE
Removed ionic.native.min.js from bower.json.

### DIFF
--- a/scripts/bower.json
+++ b/scripts/bower.json
@@ -2,8 +2,7 @@
   "name": "ionic-native",
   "description": "Native plugin wrappers for Cordova and Ionic with TypeScript, ES6+, Promise and Observable support",
   "main": [
-    "ionic.native.js",
-    "ionic.native.min.js"
+    "ionic.native.js"
   ],
   "authors": [
     "Max Lynch <max@ionic.io>"


### PR DESCRIPTION
When installing the bower package created from this, a couple of warnings are printed: 
 - bower ionic-native#*      invalid-meta The "main" field cannot contain minified files
 - bower ionic-native#*      invalid-meta The "main" field has to contain only 1 file per filetype; found multiple .js files: ["ionic.native.js","ionic.native.min.js"]